### PR TITLE
Add Rinkhals app packaging and release workflow

### DIFF
--- a/.github/workflows/release_rinkhals_app.yml
+++ b/.github/workflows/release_rinkhals_app.yml
@@ -1,0 +1,37 @@
+name: Release Rinkhals App
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version tag for release (e.g. v0.1.0)'
+        required: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Prepare app package
+        run: |
+          APP_DIR=dist/mobileraker-app
+          mkdir -p "$APP_DIR"
+          cp -r mobileraker mobileraker.py scripts/mobileraker-requirements.txt rinkhals/app.sh rinkhals/app.json "$APP_DIR"/
+          python -m pip install -r scripts/mobileraker-requirements.txt --target "$APP_DIR/lib/python3.11/site-packages"
+          sed -i "s/0.0.0/${{ github.event.inputs.version }}/" "$APP_DIR/app.json"
+          cd dist && zip -r "mobileraker-rinkhals-${{ github.event.inputs.version }}.zip" mobileraker-app
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ github.event.inputs.version }}
+          files: dist/mobileraker-rinkhals-${{ github.event.inputs.version }}.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/rinkhals/app.json
+++ b/rinkhals/app.json
@@ -1,0 +1,9 @@
+{
+    "$version": "1",
+    "name": "Mobileraker Companion",
+    "description": "Push notification companion for Mobileraker",
+    "version": "0.0.0",
+    "requirements": {
+        "memory": 30
+    }
+}

--- a/rinkhals/app.sh
+++ b/rinkhals/app.sh
@@ -1,0 +1,67 @@
+#!/bin/sh
+
+. /useremain/rinkhals/.current/tools.sh
+
+APP_ROOT=$(dirname $(realpath $0))
+
+status() {
+    PIDS=$(get_by_name mobileraker.py)
+    if [ "$PIDS" = "" ]; then
+        report_status $APP_STATUS_STOPPED
+    else
+        report_status $APP_STATUS_STARTED "$PIDS"
+    fi
+}
+
+start() {
+    stop
+    cd $APP_ROOT
+
+    mkdir -p $RINKHALS_HOME/mobileraker/logs
+    mkdir -p $RINKHALS_HOME/printer_data/config
+    rm -f $RINKHALS_HOME/printer_data/config/moonraker.conf
+    ln -s $RINKHALS_HOME/printer_data/config/moonraker.generated.conf $RINKHALS_HOME/printer_data/config/moonraker.conf
+
+    CONFIG_FILE="$RINKHALS_HOME/Mobileraker.conf"
+    if [ ! -f "$CONFIG_FILE" ]; then
+        cat > "$CONFIG_FILE" <<CFG
+[printer _Default]
+moonraker_uri = ws://127.0.0.1:7125/websocket
+CFG
+    fi
+
+    export PYTHONPATH="$APP_ROOT:$APP_ROOT/lib/python3.11/site-packages"
+    python mobileraker.py -c "$CONFIG_FILE" >> $RINKHALS_ROOT/logs/app-mobileraker.log 2>&1 &
+    assert_by_name mobileraker.py
+}
+
+debug() {
+    stop
+    cd $APP_ROOT
+    export PYTHONPATH="$APP_ROOT:$APP_ROOT/lib/python3.11/site-packages"
+    python mobileraker.py -c "$RINKHALS_HOME/Mobileraker.conf" "$@"
+}
+
+stop() {
+    kill_by_name mobileraker.py
+}
+
+case "$1" in
+    status)
+        status
+        ;;
+    start)
+        start
+        ;;
+    debug)
+        shift
+        debug "$@"
+        ;;
+    stop)
+        stop
+        ;;
+    *)
+        echo "Usage: $0 {status|start|stop|debug}" >&2
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
## Summary
- add app.json and control script to run Mobileraker Companion as a Rinkhals app
- provide manual GitHub Action to package and publish a Rinkhals-compatible release

## Testing
- `PYTHONPATH=. pytest tests` *(fails: AttributeError: 'int' object has no attribute 'create_task')*

------
https://chatgpt.com/codex/tasks/task_e_688e773b5668832da05f168fea381cb2