### PR TITLE
Add Rinkhals app packaging and release workflow

### DIFF
--- a/.github/workflows/release_rinkhals_app.yml
+++ b/.github/workflows/release_rinkhals_app.yml
@@ -1,0 +1,64 @@
+name: Release Rinkhals App
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version tag for release (e.g. v0.1.0)'
+        required: true
+      kobra_model:
+        description: 'Kobra model code (e.g. K3, K2P, KS1, K3M)'
+        required: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Build SWU package
+        run: |
+          APP_NAME=mobileraker
+          APP_DIR=dist/$APP_NAME
+          mkdir -p "$APP_DIR"
+          cp -r mobileraker mobileraker.py scripts/mobileraker-requirements.txt rinkhals/app.sh rinkhals/app.json "$APP_DIR"/
+          python -m pip install -r scripts/mobileraker-requirements.txt --target "$APP_DIR/lib/python3.11/site-packages"
+          sed -i "s/0.0.0/${{ github.event.inputs.version }}/" "$APP_DIR/app.json"
+
+          UPDATE_TMP=dist/update_tmp
+          mkdir -p "$UPDATE_TMP/$APP_NAME"
+          cp -r "$APP_DIR"/* "$UPDATE_TMP/$APP_NAME"/
+          cp rinkhals/update.sh "$UPDATE_TMP/update.sh"
+
+          mkdir -p dist/update_swu
+          tar -C "$UPDATE_TMP" -cf dist/update_swu/setup.tar --exclude='setup.tar' .
+          gzip dist/update_swu/setup.tar
+
+          cd dist
+          case "${{ github.event.inputs.kobra_model }}" in
+            K2P|K3)
+              zip -0 -P U2FsdGVkX19deTfqpXHZnB5GeyQ/dtlbHjkUnwgCi+w= -r update.swu update_swu
+              ;;
+            KS1)
+              zip -0 -P U2FsdGVkX1+lG6cHmshPLI/LaQr9cZCjA8HZt6Y8qmbB7riY -r update.swu update_swu
+              ;;
+            K3M)
+              zip -0 -P 4DKXtEGStWHpPgZm8Xna9qluzAI8VJzpOsEIgd8brTLiXs8fLSu3vRx8o7fMf4h6 -r update.swu update_swu
+              ;;
+            *)
+              echo 'Unknown Kobra model code'; exit 1 ;;
+          esac
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ github.event.inputs.version }}
+          files: dist/update.swu
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/rinkhals/app.json
+++ b/rinkhals/app.json
@@ -1,0 +1,9 @@
+{
+    "$version": "1",
+    "name": "Mobileraker Companion",
+    "description": "Push notification companion for Mobileraker",
+    "version": "0.0.0",
+    "requirements": {
+        "memory": 30
+    }
+}

--- a/rinkhals/app.sh
+++ b/rinkhals/app.sh
@@ -1,0 +1,74 @@
+#!/bin/sh
+
+. /useremain/rinkhals/.current/tools.sh
+
+APP_ROOT=$(dirname $(realpath $0))
+
+version() {
+    grep -o '"version" *: *"[^"]*"' "$APP_ROOT/app.json" | cut -d '"' -f4
+}
+
+status() {
+    PIDS=$(get_by_name mobileraker.py)
+    if [ "$PIDS" = "" ]; then
+        report_status $APP_STATUS_STOPPED
+    else
+        report_status $APP_STATUS_STARTED "$PIDS"
+    fi
+}
+
+start() {
+    stop
+    cd $APP_ROOT
+
+    mkdir -p $RINKHALS_HOME/mobileraker/logs
+    mkdir -p $RINKHALS_HOME/printer_data/config
+    rm -f $RINKHALS_HOME/printer_data/config/moonraker.conf
+    ln -s $RINKHALS_HOME/printer_data/config/moonraker.generated.conf $RINKHALS_HOME/printer_data/config/moonraker.conf
+
+    CONFIG_FILE="$RINKHALS_HOME/Mobileraker.conf"
+    if [ ! -f "$CONFIG_FILE" ]; then
+        cat > "$CONFIG_FILE" <<CFG
+[printer _Default]
+moonraker_uri = ws://127.0.0.1:7125/websocket
+CFG
+    fi
+
+    export PYTHONPATH="$APP_ROOT:$APP_ROOT/lib/python3.11/site-packages"
+    python mobileraker.py -c "$CONFIG_FILE" >> $RINKHALS_ROOT/logs/app-mobileraker.log 2>&1 &
+    assert_by_name mobileraker.py
+}
+
+debug() {
+    stop
+    cd $APP_ROOT
+    export PYTHONPATH="$APP_ROOT:$APP_ROOT/lib/python3.11/site-packages"
+    python mobileraker.py -c "$RINKHALS_HOME/Mobileraker.conf" "$@"
+}
+
+stop() {
+    kill_by_name mobileraker.py
+}
+
+case "$1" in
+    status)
+        status
+        ;;
+    start)
+        start
+        ;;
+    debug)
+        shift
+        debug "$@"
+        ;;
+    version)
+        version
+        ;;
+    stop)
+        stop
+        ;;
+    *)
+        echo "Usage: $0 {status|start|stop|debug|version}" >&2
+        exit 1
+        ;;
+esac

--- a/rinkhals/update.sh
+++ b/rinkhals/update.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+function beep() {
+    echo 1 > /sys/class/pwm/pwmchip0/pwm0/enable
+    usleep $(($1 * 1000))
+    echo 0 > /sys/class/pwm/pwmchip0/pwm0/enable
+}
+
+UPDATE_PATH="/useremain/update_swu"
+
+# Identify app to be installed
+APP_ROOT=$(find $UPDATE_PATH -type d -mindepth 1 -maxdepth 1 2> /dev/null)
+APP=$(basename $APP_ROOT)
+
+chmod +x $APP_ROOT/app.sh
+APP_VERSION=$($APP_ROOT/app.sh version)
+
+# Copy to final path
+DESTINATION_ROOT=/useremain/home/rinkhals/apps/$APP
+
+# TODO: Check if we are downgrading
+# if [ -f $DESTINATION_ROOT/app.sh ]; then
+#     DESTINATION_VERSION=$($DESTINATION_ROOT/app.sh version)
+#     if [ "$APP_VERSION" \> "$DESTINATION_VERSION" ]; then
+#     fi
+# fi
+
+mkdir -p $DESTINATION_ROOT
+cp -r $APP_ROOT/* $DESTINATION_ROOT/
+
+# Beep to notify completion
+beep 500


### PR DESCRIPTION
## Summary
- add app.json and control script to run Mobileraker Companion as a Rinkhals app
- provide manual GitHub Action to package and publish a Rinkhals-compatible release
- package release as password-protected SWU file for installation on Rinkhals printers

## Testing
- `PYTHONPATH=. pytest tests` *(fails: AttributeError: 'int' object has no attribute 'create_task')*


------
https://chatgpt.com/codex/tasks/task_e_688e773b5668832da05f168fea381cb2